### PR TITLE
Standalone remote client

### DIFF
--- a/ai_models/__main__.py
+++ b/ai_models/__main__.py
@@ -273,6 +273,7 @@ def _main(argv):
 def run(cfg: dict, model_args: list):
     if cfg["remote_execution"]:
         from .remote import RemoteModel
+
         model = RemoteModel(**cfg, model_args=model_args)
     else:
         model = load_model(cfg["model"], **cfg, model_args=model_args)

--- a/ai_models/__main__.py
+++ b/ai_models/__main__.py
@@ -271,7 +271,11 @@ def _main(argv):
 
 
 def run(cfg: dict, model_args: list):
-    model = load_model(cfg["model"], **cfg, model_args=model_args)
+    if cfg["remote_execution"]:
+        from .remote import RemoteModel
+        model = RemoteModel(**cfg, model_args=model_args)
+    else:
+        model = load_model(cfg["model"], **cfg, model_args=model_args)
 
     if cfg["fields"]:
         model.print_fields()
@@ -289,10 +293,7 @@ def run(cfg: dict, model_args: list):
         sys.exit(0)
 
     try:
-        if cfg["remote_execution"]:
-            model.remote(cfg, model_args)
-        else:
-            model.run()
+        model.run()
     except FileNotFoundError as e:
         LOG.exception(e)
         LOG.error(

--- a/ai_models/__main__.py
+++ b/ai_models/__main__.py
@@ -216,7 +216,7 @@ def _main(argv):
         parser.add_argument(
             "model",
             metavar="MODEL",
-            choices=available_models(),
+            choices=available_models() if "--remote" not in argv else None,
             help="The model to run",
         )
 

--- a/ai_models/__main__.py
+++ b/ai_models/__main__.py
@@ -239,7 +239,7 @@ def _main(argv):
             if len(models) == 0:
                 print(f"No remote models available on {api.url}")
                 sys.exit(0)
-            print(f"Models available on remote server {api.url}:")
+            print(f"Models available on remote server {api.url}")
         else:
             models = available_models()
 

--- a/ai_models/__main__.py
+++ b/ai_models/__main__.py
@@ -231,7 +231,19 @@ def _main(argv):
     args, unknownargs = parser.parse_known_args(argv)
 
     if args.models:
-        for p in sorted(available_models()):
+        if args.remote_execution:
+            from .remote import RemoteAPI
+
+            api = RemoteAPI()
+            models = api.models()
+            if len(models) == 0:
+                print(f"No remote models available on {api.url}")
+                sys.exit(0)
+            print(f"Models available on remote server {api.url}:")
+        else:
+            models = available_models()
+
+        for p in sorted(models):
             print(p)
         sys.exit(0)
 

--- a/ai_models/model.py
+++ b/ai_models/model.py
@@ -10,7 +10,6 @@ import json
 import logging
 import os
 import sys
-import tempfile
 import time
 from collections import defaultdict
 from functools import cached_property

--- a/ai_models/model.py
+++ b/ai_models/model.py
@@ -24,7 +24,6 @@ from multiurl import download
 from .checkpoint import peek
 from .inputs import get_input
 from .outputs import get_output
-from .remote import RemoteClient
 from .stepper import Stepper
 
 LOG = logging.getLogger(__name__)
@@ -457,23 +456,6 @@ class Model:
                         time=int(self.start_datetime.strftime("%H%M")),
                         check=True,
                     )
-
-    def remote(self, cfg: dict, model_args: list):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            input_file = os.path.join(tmpdirname, "input.grib")
-            output_file = os.path.join(tmpdirname, "output.grib")
-            self.all_fields.save(input_file)
-
-            client = RemoteClient(
-                input_file=input_file,
-                output_file=output_file,
-            )
-
-            client.run(cfg, model_args)
-
-            ds = cml.load_source("file", output_file)
-            for field in ds:
-                self.write(None, template=field)
 
 
 def load_model(name, **kwargs):

--- a/ai_models/remote.py
+++ b/ai_models/remote.py
@@ -21,7 +21,7 @@ class RemoteModel(Model):
         self.cfg["download_assets"] = False
         self.cfg["assets_extra_dir"] = None
         self._param = {}
-        self.api = RemoteClient()
+        self.api = RemoteAPI()
 
         super().__init__(**self.cfg)
 
@@ -88,7 +88,7 @@ class BearerAuth(requests.auth.AuthBase):
         return r
 
 
-class RemoteClient:
+class RemoteAPI:
     def __init__(
         self,
         input_file: str = None,

--- a/ai_models/remote.py
+++ b/ai_models/remote.py
@@ -213,6 +213,14 @@ class RemoteAPI:
         else:
             raise ValueError("param must be a string, list, or dict with 'param' key.")
 
+    def models(self):
+        results = self._request(requests.get, "models")
+
+        if not isinstance(results, list):
+            return []
+
+        return results
+
     def _request(self, type, href, data=None, json=None, auth=None):
         response = robust(type, retry_after=30)(
             urljoin(self.url, href),
@@ -229,7 +237,7 @@ class RemoteAPI:
         try:
             data = response.json()
 
-            if status := data.get("status"):
+            if isinstance(data, dict) and (status := data.get("status")):
                 data["status"] = status.lower()
 
             return data

--- a/ai_models/remote.py
+++ b/ai_models/remote.py
@@ -164,6 +164,8 @@ class RemoteAPI:
 
         if data["status"] != "success":
             LOG.error(data["status"])
+            if reason := data.get("reason"):
+                LOG.error(reason)
             sys.exit(1)
 
         # submit task
@@ -173,6 +175,8 @@ class RemoteAPI:
 
         if data["status"] != "queued":
             LOG.error(data["status"])
+            if reason := data.get("reason"):
+                LOG.error(reason)
             sys.exit(1)
 
         LOG.info("Request id: %s", data["id"])
@@ -188,6 +192,8 @@ class RemoteAPI:
                 last_status = data["status"]
 
             if data["status"] == "failed":
+                if reason := data.get("reason"):
+                    LOG.error(reason)
                 sys.exit(1)
 
             if data["status"] == "ready":

--- a/ai_models/remote.py
+++ b/ai_models/remote.py
@@ -25,6 +25,8 @@ class RemoteModel(Model):
         self._param = {}
         self.api = RemoteAPI()
 
+        self.load_parameters()
+
         super().__init__(**self.cfg)
 
     def __getattr__(self, name):
@@ -47,6 +49,24 @@ class RemoteModel(Model):
 
     def parse_model_args(self, args):
         return None
+
+    def load_parameters(self):
+        params = self.api.metadata(
+            self.model,
+            [
+                "expver",
+                "version",
+                "grid",
+                "area",
+                "param_level_ml",
+                "param_level_pl",
+                "param_sfc",
+                "lagged",
+                "grib_extra_metadata",
+                "retrieve",
+            ],
+        )
+        self._param.update(params)
 
     def get_parameter(self, name):
         if (param := self._param.get(name, None)) is not None:

--- a/ai_models/remote.py
+++ b/ai_models/remote.py
@@ -138,16 +138,17 @@ class RemoteAPI:
             with open(configfile, "r") as f:
                 config = safe_load(f) or {}
 
-                url = config.get("url", None)
-                token = config.get("token", None)
+        url = (
+            url
+            or os.getenv("AI_MODELS_REMOTE_URL")
+            or config.get("url")
+            or "https://ai-models.ecmwf.int"
+        )
+        LOG.info("Using remote server %s", url)
 
-        if url is None:
-            url = os.getenv("AI_MODELS_REMOTE_URL", "https://ai-models.ecmwf.int")
-            LOG.info("Using remote server %s", url)
+        token = token or os.getenv("AI_MODELS_REMOTE_TOKEN") or config.get("token")
 
-        token = token or os.getenv("AI_MODELS_REMOTE_TOKEN", None)
-
-        if token is None:
+        if not token:
             LOG.error(
                 "Missing remote token. Set it in %s or in env AI_MODELS_REMOTE_TOKEN",
                 configfile,

--- a/ai_models/remote/__init__.py
+++ b/ai_models/remote/__init__.py
@@ -1,0 +1,4 @@
+from .api import RemoteAPI
+from .model import RemoteModel
+
+__all__ = ["RemoteAPI", "RemoteModel"]

--- a/ai_models/remote/api.py
+++ b/ai_models/remote/api.py
@@ -124,11 +124,15 @@ class RemoteAPI:
 
         LOG.debug("Result written to %s", self.output_file)
 
-    def metadata(self, model, param) -> dict:
+    def metadata(self, model, model_version, param) -> dict:
         if isinstance(param, str):
-            return self._request(requests.get, f"metadata/{model}/{param}")
+            return self._request(
+                requests.get, f"metadata/{model}/{model_version}/{param}"
+            )
         elif isinstance(param, (list, dict)):
-            return self._request(requests.post, f"metadata/{model}", json=param)
+            return self._request(
+                requests.post, f"metadata/{model}/{model_version}", json=param
+            )
         else:
             raise ValueError("param must be a string, list, or dict with 'param' key.")
 

--- a/ai_models/remote/api.py
+++ b/ai_models/remote/api.py
@@ -1,113 +1,14 @@
 import logging
 import os
 import sys
-import tempfile
 import time
-from functools import cached_property
 from urllib.parse import urljoin
 
-import climetlab as cml
 import requests
 from multiurl import download, robust
 from tqdm import tqdm
 
-from .model import Model
-
 LOG = logging.getLogger(__name__)
-
-
-class RemoteModel(Model):
-    def __init__(self, **kwargs):
-        self.cfg = kwargs
-        self.cfg["download_assets"] = False
-        self.cfg["assets_extra_dir"] = None
-
-        self.model = self.cfg["model"]
-        self._param = {}
-        self.api = RemoteAPI()
-
-        self.load_parameters()
-
-        super().__init__(**self.cfg)
-
-    def __getattr__(self, name):
-        return self.get_parameter(name)
-
-    def run(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            input_file = os.path.join(tmpdirname, "input.grib")
-            output_file = os.path.join(tmpdirname, "output.grib")
-            self.all_fields.save(input_file)
-
-            self.api.input_file = input_file
-            self.api.output_file = output_file
-
-            self.api.run(self.cfg)
-
-            ds = cml.load_source("file", output_file)
-            for field in ds:
-                self.write(None, template=field)
-
-    def parse_model_args(self, args):
-        return None
-
-    def patch_retrieve_request(self, request):
-        patched = self.api.patch_retrieve_request(self.cfg, request)
-        request.update(patched)
-
-    def load_parameters(self):
-        params = self.api.metadata(
-            self.model,
-            [
-                "expver",
-                "version",
-                "grid",
-                "area",
-                "param_level_ml",
-                "param_level_pl",
-                "param_sfc",
-                "lagged",
-                "grib_extra_metadata",
-                "retrieve",
-            ],
-        )
-        self._param.update(params)
-
-    def get_parameter(self, name):
-        if (param := self._param.get(name, None)) is not None:
-            return param
-
-        self._param.update(self.api.metadata(self.model, name))
-
-        return self._param[name]
-
-    @cached_property
-    def param_level_ml(self):
-        return self.get_parameter("param_level_ml") or ([], [])
-
-    @cached_property
-    def param_level_pl(self):
-        return self.get_parameter("param_level_pl") or ([], [])
-
-    @cached_property
-    def param_sfc(self):
-        return self.get_parameter("param_sfc") or []
-
-    @cached_property
-    def lagged(self):
-        return self.get_parameter("lagged") or False
-
-    @cached_property
-    def version(self):
-        return self.get_parameter("version") or 1
-
-    @cached_property
-    def grib_extra_metadata(self):
-        return self.get_parameter("grib_extra_metadata") or {}
-
-    @cached_property
-    def retrieve(self):
-        return self.get_parameter("retrieve") or {}
 
 
 class BearerAuth(requests.auth.AuthBase):

--- a/ai_models/remote/api.py
+++ b/ai_models/remote/api.py
@@ -35,6 +35,9 @@ class RemoteAPI:
         self.url = (
             url or os.getenv("AI_MODELS_REMOTE_URL") or config.get("url") or API_URL
         )
+        if not self.url.endswith("/"):
+            self.url += "/"
+
         self.token = token or os.getenv("AI_MODELS_REMOTE_TOKEN") or config.get("token")
 
         if not self.token:
@@ -66,7 +69,7 @@ class RemoteAPI:
         # submit task
         data = self._request(requests.post, data["href"], json=cfg)
 
-        LOG.info("Request submitted")
+        LOG.info("Inference request submitted")
 
         if data["status"] != "queued":
             LOG.error(data["status"])

--- a/ai_models/remote/config.py
+++ b/ai_models/remote/config.py
@@ -1,0 +1,42 @@
+import logging
+import os
+
+API_URL = "https://ai-models.ecmwf.int"
+
+ROOT_PATH = os.path.join(os.path.expanduser("~"), ".config", "ai-models")
+CONFIG_PATH = os.path.join(ROOT_PATH, "api.yaml")
+
+LOG = logging.getLogger(__name__)
+
+
+def config_exists():
+    return os.path.exists(CONFIG_PATH)
+
+
+def create_config():
+    if config_exists():
+        return
+
+    try:
+        os.makedirs(ROOT_PATH, exist_ok=True)
+        with open(CONFIG_PATH, "w") as f:
+            f.write("token: \n")
+            f.write(f"url: {API_URL}\n")
+    except Exception as e:
+        LOG.error(f"Failed to create config {CONFIG_PATH}")
+        LOG.error(e, exc_info=True)
+
+
+def load_config() -> dict:
+    from yaml import safe_load
+
+    if not config_exists():
+        create_config()
+
+    try:
+        with open(CONFIG_PATH, "r") as f:
+            return safe_load(f) or {}
+    except Exception as e:
+        LOG.error(f"Failed to read config {CONFIG_PATH}")
+        LOG.error(e, exc_info=True)
+        return {}

--- a/ai_models/remote/config.py
+++ b/ai_models/remote/config.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-API_URL = "https://ai-models.ecmwf.int"
+API_URL = "https://ai-models.ecmwf.int/api/v1/"
 
 ROOT_PATH = os.path.join(os.path.expanduser("~"), ".config", "ai-models")
 CONFIG_PATH = os.path.join(ROOT_PATH, "api.yaml")

--- a/ai_models/remote/model.py
+++ b/ai_models/remote/model.py
@@ -56,6 +56,9 @@ class RemoteModel(Model):
         return None
 
     def patch_retrieve_request(self, request):
+        if not self.remote_has_patch:
+            return
+
         patched = self.api.patch_retrieve_request(self.cfg, request)
         request.update(patched)
 
@@ -74,6 +77,7 @@ class RemoteModel(Model):
                 "lagged",
                 "grib_extra_metadata",
                 "retrieve",
+                "remote_has_patch",  # this is a custom parameter that checks if the remote model implemented patch_retrieve_request
             ],
         )
         self._param.update(params)

--- a/ai_models/remote/model.py
+++ b/ai_models/remote/model.py
@@ -19,6 +19,7 @@ class RemoteModel(Model):
         self.cfg["assets_extra_dir"] = None
 
         self.model = self.cfg["model"]
+        self.model_version = self.cfg.get("model_version", "latest")
         self._param = {}
         self.api = RemoteAPI()
 
@@ -61,6 +62,7 @@ class RemoteModel(Model):
     def load_parameters(self):
         params = self.api.metadata(
             self.model,
+            self.model_version,
             [
                 "expver",
                 "version",
@@ -80,7 +82,8 @@ class RemoteModel(Model):
         if (param := self._param.get(name)) is not None:
             return param
 
-        self._param.update(self.api.metadata(self.model, name))
+        _param = self.api.metadata(self.model, self.model_version, name)
+        self._param.update(_param)
 
         return self._param.get(name)
 

--- a/ai_models/remote/model.py
+++ b/ai_models/remote/model.py
@@ -1,4 +1,6 @@
+import logging
 import os
+import sys
 import tempfile
 from functools import cached_property
 
@@ -6,6 +8,8 @@ import climetlab as cml
 
 from ..model import Model
 from .api import RemoteAPI
+
+LOG = logging.getLogger(__name__)
 
 
 class RemoteModel(Model):
@@ -17,6 +21,13 @@ class RemoteModel(Model):
         self.model = self.cfg["model"]
         self._param = {}
         self.api = RemoteAPI()
+
+        if self.model not in self.api.models():
+            LOG.error(f"Model '{self.model}' not available on remote server.")
+            LOG.error(
+                "Rerun the command with --models --remote to list available remote models."
+            )
+            sys.exit(1)
 
         self.load_parameters()
 

--- a/ai_models/remote/model.py
+++ b/ai_models/remote/model.py
@@ -1,0 +1,102 @@
+import os
+import tempfile
+from functools import cached_property
+
+import climetlab as cml
+
+from ..model import Model
+from .api import RemoteAPI
+
+
+class RemoteModel(Model):
+    def __init__(self, **kwargs):
+        self.cfg = kwargs
+        self.cfg["download_assets"] = False
+        self.cfg["assets_extra_dir"] = None
+
+        self.model = self.cfg["model"]
+        self._param = {}
+        self.api = RemoteAPI()
+
+        self.load_parameters()
+
+        super().__init__(**self.cfg)
+
+    def __getattr__(self, name):
+        return self.get_parameter(name)
+
+    def run(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            input_file = os.path.join(tmpdirname, "input.grib")
+            output_file = os.path.join(tmpdirname, "output.grib")
+            self.all_fields.save(input_file)
+
+            self.api.input_file = input_file
+            self.api.output_file = output_file
+
+            self.api.run(self.cfg)
+
+            ds = cml.load_source("file", output_file)
+            for field in ds:
+                self.write(None, template=field)
+
+    def parse_model_args(self, args):
+        return None
+
+    def patch_retrieve_request(self, request):
+        patched = self.api.patch_retrieve_request(self.cfg, request)
+        request.update(patched)
+
+    def load_parameters(self):
+        params = self.api.metadata(
+            self.model,
+            [
+                "expver",
+                "version",
+                "grid",
+                "area",
+                "param_level_ml",
+                "param_level_pl",
+                "param_sfc",
+                "lagged",
+                "grib_extra_metadata",
+                "retrieve",
+            ],
+        )
+        self._param.update(params)
+
+    def get_parameter(self, name):
+        if (param := self._param.get(name, None)) is not None:
+            return param
+
+        self._param.update(self.api.metadata(self.model, name))
+
+        return self._param[name]
+
+    @cached_property
+    def param_level_ml(self):
+        return self.get_parameter("param_level_ml") or ([], [])
+
+    @cached_property
+    def param_level_pl(self):
+        return self.get_parameter("param_level_pl") or ([], [])
+
+    @cached_property
+    def param_sfc(self):
+        return self.get_parameter("param_sfc") or []
+
+    @cached_property
+    def lagged(self):
+        return self.get_parameter("lagged") or False
+
+    @cached_property
+    def version(self):
+        return self.get_parameter("version") or 1
+
+    @cached_property
+    def grib_extra_metadata(self):
+        return self.get_parameter("grib_extra_metadata") or {}
+
+    @cached_property
+    def retrieve(self):
+        return self.get_parameter("retrieve") or {}

--- a/ai_models/remote/model.py
+++ b/ai_models/remote/model.py
@@ -16,7 +16,6 @@ class RemoteModel(Model):
     def __init__(self, **kwargs):
         self.cfg = kwargs
         self.cfg["download_assets"] = False
-        self.cfg["assets_extra_dir"] = None
 
         self.model = self.cfg["model"]
         self.model_version = self.cfg.get("model_version", "latest")
@@ -77,7 +76,7 @@ class RemoteModel(Model):
                 "lagged",
                 "grib_extra_metadata",
                 "retrieve",
-                "remote_has_patch",  # this is a custom parameter that checks if the remote model implemented patch_retrieve_request
+                "remote_has_patch",  # custom parameter, checks if remote model need patches
             ],
         )
         self._param.update(params)

--- a/ai_models/remote/model.py
+++ b/ai_models/remote/model.py
@@ -77,12 +77,12 @@ class RemoteModel(Model):
         self._param.update(params)
 
     def get_parameter(self, name):
-        if (param := self._param.get(name, None)) is not None:
+        if (param := self._param.get(name)) is not None:
             return param
 
         self._param.update(self.api.metadata(self.model, name))
 
-        return self._param[name]
+        return self._param.get(name)
 
     @cached_property
     def param_level_ml(self):

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ import os
 
 import setuptools
 
+from ai_models.remote.config import config_exists, create_config
+
 
 def read(fname):
     file_path = os.path.join(os.path.dirname(__file__), fname)
@@ -27,6 +29,9 @@ for line in read("ai_models/__init__.py").split("\n"):
 
 
 assert version
+
+if not config_exists():
+    create_config()
 
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setuptools.setup(
         "gputil",
         "earthkit-meteo",
         "pyyaml",
+        "tqdm",
     ],
     extras_require={
         "provenance": [


### PR DESCRIPTION
Remote execution no longer needs a local copy of trained model assets. Checkpoint data (and any missing local model parameter) is fetched from the server. Tested and working for all model plugins.

Also supports remote `patch_retrieve_requests`, the server will send back the patched request if the model requires it.

Changes:

- Adds a new model class `RemoteModel` that handles the remote model run and parameter fetching
- Add a tqdm progress bar during remote inference
- All the remote code now lives in its own subpackage `remote`
- Create an empty remote config file during pip install at `~/.config/ai-models/api.yaml`
- Remote models can be queried with `--models --remote`
