### PR TITLE
Update earthkit.data to >=0.11.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 
 dependencies = [
     "cdsapi",
-    "earthkit-data>=0.10.3",
+    "earthkit-data>=0.11.3",
     "earthkit-meteo",
     "earthkit-regrid",
     "eccodes>=2.37",


### PR DESCRIPTION
`earthkit.data` has been updated, but any version prior to `0.11.3` will break the models.

Closes #64 